### PR TITLE
Allow Optentip Options Passthrough

### DIFF
--- a/src/components/option-list-item.js
+++ b/src/components/option-list-item.js
@@ -23,7 +23,7 @@ var OptionListItem = createReactClass({
     if(component === null || this.tooltip || this.isMobile()) {
       return;
     }
-
+    console.log('testing targetted commit package pulling.')
     this.tooltip = new Opentip(component, this.props.toolTipContent, this.props.toolTipTitle, this.props.openTipOptions);
   },
   componentDidUpdate: function() {

--- a/src/components/option-list-item.js
+++ b/src/components/option-list-item.js
@@ -23,7 +23,6 @@ var OptionListItem = createReactClass({
     if(component === null || this.tooltip || this.isMobile()) {
       return;
     }
-    console.log('testing targetted commit package pulling.')
     this.tooltip = new Opentip(component, this.props.toolTipContent, this.props.toolTipTitle, this.props.openTipOptions);
   },
   componentDidUpdate: function() {

--- a/src/components/option-list.js
+++ b/src/components/option-list.js
@@ -1,10 +1,10 @@
-var React = require("react");
-var createReactClass = require("create-react-class");
-var types = require("prop-types");
-var OptionListItem = require("./option-list-item");
-var LazyRender = require("react-lazy-render");
-var ReactSizeBox = require("react-sizebox");
-var classes = require("classnames");
+var React = require('react');
+var createReactClass = require('create-react-class');
+var types = require('prop-types');
+var OptionListItem = require('./option-list-item');
+var LazyRender = require('react-lazy-render');
+var ReactSizeBox = require('react-sizebox');
+var classes = require('classnames');
 
 var OptionList = createReactClass({
   propTypes: {
@@ -12,7 +12,7 @@ var OptionList = createReactClass({
     onClick: types.func,
     addAll: types.bool,
     addAllFunc: types.func,
-    openTipOptions: types.object,
+    openTipOptions: types.object
   },
   buildOption: function (opt, index) {
     if (opt.addAll) {
@@ -27,8 +27,8 @@ var OptionList = createReactClass({
       );
     }
 
-    var toolTipContent = "",
-      toolTipTitle = "",
+    var toolTipContent = '',
+      toolTipTitle = '',
       label;
     if (opt.toolTipContent) toolTipContent = String(opt.toolTipContent);
     if (opt.toolTipTitle) toolTipTitle = String(opt.toolTipTitle);
@@ -36,8 +36,8 @@ var OptionList = createReactClass({
     else label = opt.label;
 
     var className = classes({
-      "rxs-item-even": index % 2 === 0,
-      "rxs-item-odd": index % 2 === 1,
+      'rxs-item-even': index % 2 === 0,
+      'rxs-item-odd': index % 2 === 1
     });
 
     return (
@@ -73,7 +73,7 @@ var OptionList = createReactClass({
         </ReactSizeBox>
       </div>
     );
-  },
+  }
 });
 
 module.exports = OptionList;

--- a/src/components/option-list.js
+++ b/src/components/option-list.js
@@ -1,39 +1,44 @@
-var React = require('react');
-var createReactClass = require('create-react-class');
-var types = require('prop-types');
-var OptionListItem = require('./option-list-item');
-var LazyRender = require('react-lazy-render');
-var ReactSizeBox = require('react-sizebox');
-var classes = require('classnames');
+var React = require("react");
+var createReactClass = require("create-react-class");
+var types = require("prop-types");
+var OptionListItem = require("./option-list-item");
+var LazyRender = require("react-lazy-render");
+var ReactSizeBox = require("react-sizebox");
+var classes = require("classnames");
 
 var OptionList = createReactClass({
   propTypes: {
     options: types.array,
     onClick: types.func,
     addAll: types.bool,
-    addAllFunc: types.func
+    addAllFunc: types.func,
+    openTipOptions: types.object,
   },
-  buildOption: function(opt, index){
-    if(opt.addAll) {
+  buildOption: function (opt, index) {
+    if (opt.addAll) {
       return (
         <OptionListItem
-          key='Add All'
+          key="Add All"
           addAll={this.props.addAll}
           onClick={this.props.addAllFunc}
-          value={'Add All'}
-          label='Add All' />
+          value={"Add All"}
+          label="Add All"
+        />
       );
     }
 
-    var toolTipContent = '', toolTipTitle = '', label;
-    if(opt.toolTipContent) toolTipContent = String(opt.toolTipContent);
-    if(opt.toolTipTitle) toolTipTitle = String(opt.toolTipTitle);
-    if(opt.labelComponent)
-      label = opt.labelComponent;
-    else
-      label = opt.label;
+    var toolTipContent = "",
+      toolTipTitle = "",
+      label;
+    if (opt.toolTipContent) toolTipContent = String(opt.toolTipContent);
+    if (opt.toolTipTitle) toolTipTitle = String(opt.toolTipTitle);
+    if (opt.labelComponent) label = opt.labelComponent;
+    else label = opt.label;
 
-    var className = classes({'rxs-item-even': index % 2 === 0, 'rxs-item-odd': index % 2 === 1});
+    var className = classes({
+      "rxs-item-even": index % 2 === 0,
+      "rxs-item-odd": index % 2 === 1,
+    });
 
     return (
       <OptionListItem
@@ -45,29 +50,30 @@ var OptionList = createReactClass({
         toolTipContent={toolTipContent}
         toolTipTitle={toolTipTitle}
         onMobileTooltip={this.props.onMobileTooltip}
-        openTipOptions={this.props.openTipOptions} />
+        openTipOptions={this.props.openTipOptions}
+      />
     );
-
   },
-  render: function() {
-    if(this.props.addAll) {
-      this.props.options.unshift({addAll: true});
+  render: function () {
+    if (this.props.addAll) {
+      this.props.options.unshift({ addAll: true });
     }
 
     return (
-      <div className='content'>
-        <ReactSizeBox className='overflow-y rsx-SizeBox' heightProp='maxHeight'>
+      <div className="content">
+        <ReactSizeBox className="overflow-y rsx-SizeBox" heightProp="maxHeight">
           <LazyRender
-            className='rxs-option-list rsx-lazyRender'
+            className="rxs-option-list rsx-lazyRender"
             generatorData={this.props.options}
             generatorFunction={this.buildOption}
-            maxHeight={400}>
+            maxHeight={400}
+          >
             <li>None Found</li>
           </LazyRender>
         </ReactSizeBox>
       </div>
     );
-  }
+  },
 });
 
 module.exports = OptionList;

--- a/src/components/option-list.js
+++ b/src/components/option-list.js
@@ -44,7 +44,8 @@ var OptionList = createReactClass({
         label={label}
         toolTipContent={toolTipContent}
         toolTipTitle={toolTipTitle}
-        onMobileTooltip={this.props.onMobileTooltip}/>
+        onMobileTooltip={this.props.onMobileTooltip}
+        openTipOptions={this.props.openTipOptions} />
     );
 
   },

--- a/src/react-xzibit-select.js
+++ b/src/react-xzibit-select.js
@@ -1,24 +1,30 @@
-var React = require('react');
-var createReactClass = require('create-react-class');
-var update = require('react-addons-update');
-var types = require('prop-types');
-var OptionList = require('./components/option-list');
-var ReactCompactMultiselect = require('react-compact-multiselect');
-var TagList = require('react-tag-list');
-var SkyLight = require('react-skylight').default;
-var IsMobileMixin = require('react-ismobile-mixin');
-var lunr = require('lunr')
-var _ = require('lodash')
-var ReactDebounceInput = require('react-debounce-input')
-var DebounceInput = ReactDebounceInput.DebounceInput
-require('./react-xzibit-select.scss');
+var React = require("react");
+var createReactClass = require("create-react-class");
+var update = require("react-addons-update");
+var types = require("prop-types");
+var OptionList = require("./components/option-list");
+var ReactCompactMultiselect = require("react-compact-multiselect");
+var TagList = require("react-tag-list");
+var SkyLight = require("react-skylight").default;
+var IsMobileMixin = require("react-ismobile-mixin");
+var lunr = require("lunr");
+var _ = require("lodash");
+var ReactDebounceInput = require("react-debounce-input");
+var DebounceInput = ReactDebounceInput.DebounceInput;
+require("./react-xzibit-select.scss");
 
 var XzibitSelect = createReactClass({
-  getInitialState: function() {
+  getInitialState: function () {
     return {
       mobileTooltipContent: null,
       mobileTooltipTitle: null,
-      searchIndex: this.generateSearchIndex(this.props.searchFields, this.props.refField, this.props.options, this.props.values, this.props.dimensionFilters)
+      searchIndex: this.generateSearchIndex(
+        this.props.searchFields,
+        this.props.refField,
+        this.props.options,
+        this.props.values,
+        this.props.dimensionFilters
+      ),
     };
   },
 
@@ -33,199 +39,271 @@ var XzibitSelect = createReactClass({
     onDimensionSelectionChange: types.func,
     onDimensionFilterValueChange: types.func,
     onClearDimensionFilterValue: types.func,
+    openTipOptions: types.object,
     options: types.array,
     optionsByValue: types.any,
     refField: types.string,
     searchFields: types.array,
-    values: types.array
+    values: types.array,
   },
 
   mixins: [IsMobileMixin],
 
-  getDefaultProps: function() {
+  getDefaultProps: function () {
     return {
       addAll: true,
       filterChangeThrotleMs: 200,
       dimensionFilters: {},
-      searchFilterValue: '',
+      searchFilterValue: "",
       searchFilterDebounceTime: 200,
-      placeholderText: 'Type here to filter options',
+      placeholderText: "Type here to filter options",
       openTipOptions: {
         offset: [3, 10],
         borderRadius: 2,
-        borderColor: '#333333',
-        background: '#333333',
-        className: 'rxs-tooltip',
+        borderColor: "#333333",
+        background: "#333333",
+        className: "rxs-tooltip",
         delay: 0,
         hideDelay: 0,
         showEffectDuration: 0,
         hideEffectDuration: 0,
-        tipJoint: 'top left',
-        stem: false
+        tipJoint: "top left",
+        stem: false,
       },
-      refField: 'value',
-      searchFields: ['label']
+      refField: "value",
+      searchFields: ["label"],
     };
   },
 
-  componentWillReceiveProps: function(nextProps) {
-    if(nextProps.searchFilterValue !== this.props.searchFilterValue) {
-      this.setLunrResults(nextProps.searchFilterValue)
+  componentWillReceiveProps: function (nextProps) {
+    if (nextProps.searchFilterValue !== this.props.searchFilterValue) {
+      this.setLunrResults(nextProps.searchFilterValue);
     }
   },
 
-  generateSearchIndex: function(searchFields, refField, data, currentlySelectedValues, currentDimensionFilters) {
-    var componentThis = this
-    var search = lunr(function() {
-      var lunrThis = this
+  generateSearchIndex: function (
+    searchFields,
+    refField,
+    data,
+    currentlySelectedValues,
+    currentDimensionFilters
+  ) {
+    var componentThis = this;
+    var search = lunr(function () {
+      var lunrThis = this;
       searchFields.forEach(function (field) {
-        var name = field.name || field
-        var weight = field.weight || 1
-        lunrThis.field(name, weight)
-      })
+        var name = field.name || field;
+        var weight = field.weight || 1;
+        lunrThis.field(name, weight);
+      });
 
-      lunrThis.ref(refField)
+      lunrThis.ref(refField);
 
-      componentThis.fillSearch(lunrThis, data, currentlySelectedValues, currentDimensionFilters)
-    })
+      componentThis.fillSearch(
+        lunrThis,
+        data,
+        currentlySelectedValues,
+        currentDimensionFilters
+      );
+    });
 
-    return search
+    return search;
   },
 
-  getAvailableOptions: function(options, currentlySelectedValues, currentDimensionFilters) {
+  getAvailableOptions: function (
+    options,
+    currentlySelectedValues,
+    currentDimensionFilters
+  ) {
     return options.filter(function (opt) {
-      var isSelected = currentlySelectedValues.indexOf(opt.value) !== -1
-      var isInDimension = this.dimensionFilterIncludes(opt, currentDimensionFilters)
-      return !isSelected && isInDimension
-    }, this)
+      var isSelected = currentlySelectedValues.indexOf(opt.value) !== -1;
+      var isInDimension = this.dimensionFilterIncludes(
+        opt,
+        currentDimensionFilters
+      );
+      return !isSelected && isInDimension;
+    }, this);
   },
 
-  fillSearch: function(search, options, currentlySelectedValues, currentDimensionFilters) {
+  fillSearch: function (
+    search,
+    options,
+    currentlySelectedValues,
+    currentDimensionFilters
+  ) {
     // Note that we fill the search index with all of the options, later on if there are less available options, then
     // we must remove those options from search results after the search is done.
     // This is a performance improvement, originally we would recreate the search index on every component update(eg. adding/removing options), which takes a long time for a large number of options
     options.forEach(function (opt) {
-      search.add(opt)
-    })
+      search.add(opt);
+    });
   },
 
-  subStringSearch: function (searchInput, options, currentlySelectedValues, currentDimensionFilters) {
-    return this.getAvailableOptions(options, currentlySelectedValues, currentDimensionFilters).filter(function(opt) {
-      var foundValue = false
-      for(var i = 0; i < this.props.searchFields.length; i ++){
-        var fieldValue = opt[this.props.searchFields[i]].toLowerCase()
-        // If the searchInput exists in the fieldValue
-        // break and keep this option in the list
-        if(fieldValue.indexOf(searchInput) > -1) {
-          foundValue = true
-          break
-        }
-      }
-      return foundValue
-    }.bind(this))
-    .map(function(opt) { return opt[this.props.refField]}, this)
+  subStringSearch: function (
+    searchInput,
+    options,
+    currentlySelectedValues,
+    currentDimensionFilters
+  ) {
+    return this.getAvailableOptions(
+      options,
+      currentlySelectedValues,
+      currentDimensionFilters
+    )
+      .filter(
+        function (opt) {
+          var foundValue = false;
+          for (var i = 0; i < this.props.searchFields.length; i++) {
+            var fieldValue = opt[this.props.searchFields[i]].toLowerCase();
+            // If the searchInput exists in the fieldValue
+            // break and keep this option in the list
+            if (fieldValue.indexOf(searchInput) > -1) {
+              foundValue = true;
+              break;
+            }
+          }
+          return foundValue;
+        }.bind(this)
+      )
+      .map(function (opt) {
+        return opt[this.props.refField];
+      }, this);
   },
 
-  removeValue: function(valToRemove) {
-    var newValueState = this.props.values.filter(function(val){
+  removeValue: function (valToRemove) {
+    var newValueState = this.props.values.filter(function (val) {
       return val !== valToRemove;
     });
     this.props.onChange(newValueState);
   },
 
-  removeAll: function() {
+  removeAll: function () {
     this.props.onChange([]);
   },
 
-  addValue: function(valToAdd){
+  addValue: function (valToAdd) {
     var newValueState = this.props.values.slice(0);
     newValueState.push(valToAdd);
     this.props.onChange(newValueState);
   },
 
-  addAllFunc: function() {
-    var filteredOptionValues = this.filteredOptions(this.props.options, this.props.values, this.props.dimensionFilters).map(function(opt){ return opt.value;});
+  addAllFunc: function () {
+    var filteredOptionValues = this.filteredOptions(
+      this.props.options,
+      this.props.values,
+      this.props.dimensionFilters
+    ).map(function (opt) {
+      return opt.value;
+    });
     var newValueState = filteredOptionValues.concat(this.props.values);
     this.props.onChange(newValueState);
   },
 
   mergeResults: function (array1, array2) {
     // Remove any values from array1 that exist in array2
-    var array2MinusArray1 = array2.filter(function(a2Element) {
-      return array1.indexOf(a2Element) === -1
-    })
+    var array2MinusArray1 = array2.filter(function (a2Element) {
+      return array1.indexOf(a2Element) === -1;
+    });
     // Then concat the arrays that now have no duplicates
     // This is more performant than doing the concat upfront
-    return array1.concat(array2MinusArray1)
+    return array1.concat(array2MinusArray1);
   },
 
-  setLunrResults: function(searchFilterValue) {
+  setLunrResults: function (searchFilterValue) {
     // search using the lunr search index
-    var lunrResults = this.state.searchIndex.search(searchFilterValue.toLowerCase())
-    .map(function(result) {
-      return result.ref
-    }).map(function(result) {
-      return String(result) // make sure the ref is a string for merging results comparison later
-    })
+    var lunrResults = this.state.searchIndex
+      .search(searchFilterValue.toLowerCase())
+      .map(function (result) {
+        return result.ref;
+      })
+      .map(function (result) {
+        return String(result); // make sure the ref is a string for merging results comparison later
+      });
 
-    this.setState({ lunrResults: lunrResults })
+    this.setState({ lunrResults: lunrResults });
   },
 
-  filteredOptions: function(options, currentlySelectedValues, currentDimensionFilters) {
-    var searchFilterValue = this.props.searchFilterValue.toLowerCase()
-    if(!searchFilterValue) {
-      return this.getAvailableOptions(options, currentlySelectedValues, currentDimensionFilters)
+  filteredOptions: function (
+    options,
+    currentlySelectedValues,
+    currentDimensionFilters
+  ) {
+    var searchFilterValue = this.props.searchFilterValue.toLowerCase();
+    if (!searchFilterValue) {
+      return this.getAvailableOptions(
+        options,
+        currentlySelectedValues,
+        currentDimensionFilters
+      );
     }
 
     // lunr doesn't filter on a or i
-    if(searchFilterValue === 'a' || searchFilterValue === 'i') {
-      return this.getAvailableOptions(options, currentlySelectedValues, currentDimensionFilters)
+    if (searchFilterValue === "a" || searchFilterValue === "i") {
+      return this.getAvailableOptions(
+        options,
+        currentlySelectedValues,
+        currentDimensionFilters
+      );
     }
 
-    var lunrResults = this.state.lunrResults || []
-    var substringResults = this.subStringSearch(searchFilterValue.toLowerCase(), options, currentlySelectedValues, currentDimensionFilters).map(function(result) {
-      return String(result) // make sure the ref is a string for merging results comparison later
-    })
-    var mergedResults = this.mergeResults(lunrResults, substringResults)
-    var optionMap = {}
+    var lunrResults = this.state.lunrResults || [];
+    var substringResults = this.subStringSearch(
+      searchFilterValue.toLowerCase(),
+      options,
+      currentlySelectedValues,
+      currentDimensionFilters
+    ).map(function (result) {
+      return String(result); // make sure the ref is a string for merging results comparison later
+    });
+    var mergedResults = this.mergeResults(lunrResults, substringResults);
+    var optionMap = {};
     this.props.options.forEach(function (opt) {
-      var ref = opt[this.props.refField]
-      optionMap[ref] = opt
-    }, this)
-    var lunrResultsAsOptions = mergedResults.map(function(resultRef) {
-      return optionMap[resultRef]
-    })
-    var onlyAvailableResultsOptions = this.getAvailableOptions(lunrResultsAsOptions, currentlySelectedValues, currentDimensionFilters)
+      var ref = opt[this.props.refField];
+      optionMap[ref] = opt;
+    }, this);
+    var lunrResultsAsOptions = mergedResults.map(function (resultRef) {
+      return optionMap[resultRef];
+    });
+    var onlyAvailableResultsOptions = this.getAvailableOptions(
+      lunrResultsAsOptions,
+      currentlySelectedValues,
+      currentDimensionFilters
+    );
 
-    return onlyAvailableResultsOptions
+    return onlyAvailableResultsOptions;
   },
 
-  onMobileTooltip: function(title, content) {
-    if(!this.isMobile()) {
+  onMobileTooltip: function (title, content) {
+    if (!this.isMobile()) {
       return;
     }
 
     this.setState(
-      {mobileTooltipTitle: title, mobileTooltipContent: content},
-      this.refs.tooltip.show);
+      { mobileTooltipTitle: title, mobileTooltipContent: content },
+      this.refs.tooltip.show
+    );
   },
 
-  dimensionFilterIncludes: function(opt, currentDimensionFilters) {
-    if (Object.keys(currentDimensionFilters).length < 1){
+  dimensionFilterIncludes: function (opt, currentDimensionFilters) {
+    if (Object.keys(currentDimensionFilters).length < 1) {
       return true;
     }
 
     var retVal = true;
-    var filterHits = this.props.filterDimensionOptions.map(function(dimension){
+    var filterHits = this.props.filterDimensionOptions.map(function (
+      dimension
+    ) {
       var key = dimension.key;
       var name = dimension.name;
-      var filterVals = (currentDimensionFilters[name]) ? currentDimensionFilters[name].selectedValues : undefined
+      var filterVals = currentDimensionFilters[name]
+        ? currentDimensionFilters[name].selectedValues
+        : undefined;
       if (filterVals === undefined || filterVals.length < 1) {
         return true;
       }
-      if (Array.isArray(opt[key])){
+      if (Array.isArray(opt[key])) {
         var found = false;
-        opt[key].forEach(function(optVal){
+        opt[key].forEach(function (optVal) {
           if (filterVals.indexOf(optVal) > -1) {
             found = true;
           }
@@ -237,10 +315,11 @@ var XzibitSelect = createReactClass({
         }
       }
       return false;
-    }, this);
+    },
+    this);
 
-    filterHits.forEach(function(fh){
-      if (!fh){
+    filterHits.forEach(function (fh) {
+      if (!fh) {
         retVal = false;
       }
     });
@@ -248,51 +327,59 @@ var XzibitSelect = createReactClass({
     return retVal;
   },
 
-  handleSearchFilterChange: function(event) {
-    this.props.onSearchFilterChange(event.target.value)
+  handleSearchFilterChange: function (event) {
+    this.props.onSearchFilterChange(event.target.value);
   },
 
-  clearSearchFilter: function() {
-    this.props.onClearSearchFilter()
+  clearSearchFilter: function () {
+    this.props.onClearSearchFilter();
   },
 
-  updateSearchIndex: function(props) {
-    this.setState({ searchIndex: this.generateSearchIndex(props.searchFields, props.refField, props.options, props.values, props.dimensionFilters) })
+  updateSearchIndex: function (props) {
+    this.setState({
+      searchIndex: this.generateSearchIndex(
+        props.searchFields,
+        props.refField,
+        props.options,
+        props.values,
+        props.dimensionFilters
+      ),
+    });
   },
 
-  generateUpdateDimensionSelection: function(dimensionName) {
+  generateUpdateDimensionSelection: function (dimensionName) {
     // Re-generate the search index any time a dimension selection is made so that the index correctly
     // corresponds to the new list of options filtered by the dimension selection
     /**
      *  {'Source' : [], 'Sector' : []}
      */
-    return function(values) {
-      this.props.onDimensionSelectionChange(dimensionName, values)
+    return function (values) {
+      this.props.onDimensionSelectionChange(dimensionName, values);
     }.bind(this);
   },
 
-  generateUpdateDimensionFilterValue: function(dimensionName) {
-    return function(value) {
-      this.props.onDimensionFilterValueChange(dimensionName, value)
-    }.bind(this)
+  generateUpdateDimensionFilterValue: function (dimensionName) {
+    return function (value) {
+      this.props.onDimensionFilterValueChange(dimensionName, value);
+    }.bind(this);
   },
 
-  generateClearDimensionFilterValue: function(dimensionName) {
-    return function(value) {
-      this.props.onClearDimensionFilterValue(dimensionName)
-    }.bind(this)
+  generateClearDimensionFilterValue: function (dimensionName) {
+    return function (value) {
+      this.props.onClearDimensionFilterValue(dimensionName);
+    }.bind(this);
   },
 
-  tagListValues: function() {
-    var mapFunc = function(){};
+  tagListValues: function () {
+    var mapFunc = function () {};
 
     if (this.props.optionsByValue) {
-      mapFunc = function(val){
+      mapFunc = function (val) {
         return this.props.optionsByValue[val];
       };
     } else {
-      mapFunc = function(val){
-        return this.props.options.filter(function(opt){
+      mapFunc = function (val) {
+        return this.props.options.filter(function (opt) {
           return opt.value === val;
         })[0];
       };
@@ -301,72 +388,93 @@ var XzibitSelect = createReactClass({
     return this.props.values.map(mapFunc, this);
   },
 
-  getSkylight: function() {
+  getSkylight: function () {
     if (!this.isMobile()) {
       return null;
     }
 
     return (
       <SkyLight
-        ref='tooltip'
+        ref="tooltip"
         title={this.state.mobileTooltipTitle}
-        className='mobile-tooltip'>
+        className="mobile-tooltip"
+      >
         {this.state.mobileTooltipContent}
       </SkyLight>
     );
   },
 
-  getSelectFilters: function() {
-    return this.props.filterDimensionOptions.map(function(dim) {
-      var groupByKey = '';
-      if(dim.groupByKey)
-        groupByKey = dim.groupByKey;
+  getSelectFilters: function () {
+    return this.props.filterDimensionOptions.map(function (dim) {
+      var groupByKey = "";
+      if (dim.groupByKey) groupByKey = dim.groupByKey;
 
-      const dimensionFilter = this.props.dimensionFilters[dim.name] || {}
-      const selectedValuesForDimension = dimensionFilter.selectedValues || []
-      const filterValueForDimension = dimensionFilter.filterValue || ''
+      const dimensionFilter = this.props.dimensionFilters[dim.name] || {};
+      const selectedValuesForDimension = dimensionFilter.selectedValues || [];
+      const filterValueForDimension = dimensionFilter.filterValue || "";
 
-      return (<ReactCompactMultiselect
-            key={dim.name}
-            label={dim.name}
-            options={dim.options}
-            info={dim.info}
-            selectedValues={selectedValuesForDimension}
-            onSelectionChange={this.generateUpdateDimensionSelection(dim.name)}
-            filterValue={filterValueForDimension}
-            onFilterValueChange={this.generateUpdateDimensionFilterValue(dim.name)}
-            onClearFilter={this.generateClearDimensionFilterValue(dim.name)}
-            groupBy={groupByKey}
-            layoutMode={ReactCompactMultiselect.ALIGN_CONTENT_NE} />);
+      return (
+        <ReactCompactMultiselect
+          key={dim.name}
+          label={dim.name}
+          options={dim.options}
+          info={dim.info}
+          selectedValues={selectedValuesForDimension}
+          onSelectionChange={this.generateUpdateDimensionSelection(dim.name)}
+          filterValue={filterValueForDimension}
+          onFilterValueChange={this.generateUpdateDimensionFilterValue(
+            dim.name
+          )}
+          onClearFilter={this.generateClearDimensionFilterValue(dim.name)}
+          groupBy={groupByKey}
+          layoutMode={ReactCompactMultiselect.ALIGN_CONTENT_NE}
+        />
+      );
     }, this);
   },
 
-  render: function() {
-    var filteredOptions = this.filteredOptions(this.props.options, this.props.values, this.props.dimensionFilters);
+  render: function () {
+    var filteredOptions = this.filteredOptions(
+      this.props.options,
+      this.props.values,
+      this.props.dimensionFilters
+    );
     var selectFilters = this.getSelectFilters();
-    var addAll = this.props.addAll && !(this.props.addAllLimit && filteredOptions.length > this.props.addAllLimit);
+    var addAll =
+      this.props.addAll &&
+      !(
+        this.props.addAllLimit &&
+        filteredOptions.length > this.props.addAllLimit
+      );
 
     return (
-      <div className='react-xzibit-select'>
-        <div className='fluid-layout'>
-          <div className='header'>
-            <div className='rxs-label-filter'>
-              <div className='rsv-label-filter-container'>
-              <DebounceInput
-                debounceTimeout={this.props.searchFilterDebounceTime}
-                onChange={this.handleSearchFilterChange}
-                value={this.props.searchFilterValue}
-                placeholder={this.props.placeholderText}
-              />
-              <button className='rxs-label-filter-clear' name='clear-filter' onClick={this.clearSearchFilter}>&#215;</button>
+      <div className="react-xzibit-select">
+        <div className="fluid-layout">
+          <div className="header">
+            <div className="rxs-label-filter">
+              <div className="rsv-label-filter-container">
+                <DebounceInput
+                  debounceTimeout={this.props.searchFilterDebounceTime}
+                  onChange={this.handleSearchFilterChange}
+                  value={this.props.searchFilterValue}
+                  placeholder={this.props.placeholderText}
+                />
+                <button
+                  className="rxs-label-filter-clear"
+                  name="clear-filter"
+                  onClick={this.clearSearchFilter}
+                >
+                  &#215;
+                </button>
               </div>
             </div>
             <TagList
               values={this.tagListValues()}
               onRemove={this.removeValue}
               removeAll={this.removeAll}
-              placeholderText='&nbsp;'
-              collapsedRows={1} />
+              placeholderText="&nbsp;"
+              collapsedRows={1}
+            />
           </div>
           <OptionList
             options={filteredOptions}
@@ -374,17 +482,16 @@ var XzibitSelect = createReactClass({
             addAll={addAll}
             addAllFunc={this.addAllFunc}
             onMobileTooltip={this.onMobileTooltip}
-            openTipOptions={this.props.openTipOptions}/>
-          <div className='footer'>
-            <div className='filter-multiselect'>
-            {selectFilters}
-            </div>
+            openTipOptions={this.props.openTipOptions}
+          />
+          <div className="footer">
+            <div className="filter-multiselect">{selectFilters}</div>
           </div>
         </div>
         {this.getSkylight()}
       </div>
     );
-  }
+  },
 });
 
-module.exports = XzibitSelect
+module.exports = XzibitSelect;

--- a/src/react-xzibit-select.js
+++ b/src/react-xzibit-select.js
@@ -67,7 +67,7 @@ var XzibitSelect = createReactClass({
       searchFields: ['label']
     };
   },
-  
+
   componentWillReceiveProps: function(nextProps) {
     if(nextProps.searchFilterValue !== this.props.searchFilterValue) {
       this.setLunrResults(nextProps.searchFilterValue)
@@ -85,7 +85,7 @@ var XzibitSelect = createReactClass({
       })
 
       lunrThis.ref(refField)
-      
+
       componentThis.fillSearch(lunrThis, data, currentlySelectedValues, currentDimensionFilters)
     })
 
@@ -373,7 +373,8 @@ var XzibitSelect = createReactClass({
             onClick={this.addValue}
             addAll={addAll}
             addAllFunc={this.addAllFunc}
-            onMobileTooltip={this.onMobileTooltip}/>
+            onMobileTooltip={this.onMobileTooltip}
+            openTipOptions={this.props.openTipOptions}/>
           <div className='footer'>
             <div className='filter-multiselect'>
             {selectFilters}

--- a/src/react-xzibit-select.js
+++ b/src/react-xzibit-select.js
@@ -1,17 +1,17 @@
-var React = require("react");
-var createReactClass = require("create-react-class");
-var update = require("react-addons-update");
-var types = require("prop-types");
-var OptionList = require("./components/option-list");
-var ReactCompactMultiselect = require("react-compact-multiselect");
-var TagList = require("react-tag-list");
-var SkyLight = require("react-skylight").default;
-var IsMobileMixin = require("react-ismobile-mixin");
-var lunr = require("lunr");
-var _ = require("lodash");
-var ReactDebounceInput = require("react-debounce-input");
+var React = require('react');
+var createReactClass = require('create-react-class');
+var update = require('react-addons-update');
+var types = require('prop-types');
+var OptionList = require('./components/option-list');
+var ReactCompactMultiselect = require('react-compact-multiselect');
+var TagList = require('react-tag-list');
+var SkyLight = require('react-skylight').default;
+var IsMobileMixin = require('react-ismobile-mixin');
+var lunr = require('lunr');
+var _ = require('lodash');
+var ReactDebounceInput = require('react-debounce-input');
 var DebounceInput = ReactDebounceInput.DebounceInput;
-require("./react-xzibit-select.scss");
+require('./react-xzibit-select.scss');
 
 var XzibitSelect = createReactClass({
   getInitialState: function () {
@@ -24,7 +24,7 @@ var XzibitSelect = createReactClass({
         this.props.options,
         this.props.values,
         this.props.dimensionFilters
-      ),
+      )
     };
   },
 
@@ -44,7 +44,7 @@ var XzibitSelect = createReactClass({
     optionsByValue: types.any,
     refField: types.string,
     searchFields: types.array,
-    values: types.array,
+    values: types.array
   },
 
   mixins: [IsMobileMixin],
@@ -54,24 +54,24 @@ var XzibitSelect = createReactClass({
       addAll: true,
       filterChangeThrotleMs: 200,
       dimensionFilters: {},
-      searchFilterValue: "",
+      searchFilterValue: '',
       searchFilterDebounceTime: 200,
-      placeholderText: "Type here to filter options",
+      placeholderText: 'Type here to filter options',
       openTipOptions: {
         offset: [3, 10],
         borderRadius: 2,
-        borderColor: "#333333",
-        background: "#333333",
-        className: "rxs-tooltip",
+        borderColor: '#333333',
+        background: '#333333',
+        className: 'rxs-tooltip',
         delay: 0,
         hideDelay: 0,
         showEffectDuration: 0,
         hideEffectDuration: 0,
-        tipJoint: "top left",
-        stem: false,
+        tipJoint: 'top left',
+        stem: false
       },
-      refField: "value",
-      searchFields: ["label"],
+      refField: 'value',
+      searchFields: ['label']
     };
   },
 
@@ -238,7 +238,7 @@ var XzibitSelect = createReactClass({
     }
 
     // lunr doesn't filter on a or i
-    if (searchFilterValue === "a" || searchFilterValue === "i") {
+    if (searchFilterValue === 'a' || searchFilterValue === 'i') {
       return this.getAvailableOptions(
         options,
         currentlySelectedValues,
@@ -343,7 +343,7 @@ var XzibitSelect = createReactClass({
         props.options,
         props.values,
         props.dimensionFilters
-      ),
+      )
     });
   },
 
@@ -406,12 +406,12 @@ var XzibitSelect = createReactClass({
 
   getSelectFilters: function () {
     return this.props.filterDimensionOptions.map(function (dim) {
-      var groupByKey = "";
+      var groupByKey = '';
       if (dim.groupByKey) groupByKey = dim.groupByKey;
 
       const dimensionFilter = this.props.dimensionFilters[dim.name] || {};
       const selectedValuesForDimension = dimensionFilter.selectedValues || [];
-      const filterValueForDimension = dimensionFilter.filterValue || "";
+      const filterValueForDimension = dimensionFilter.filterValue || '';
 
       return (
         <ReactCompactMultiselect
@@ -491,7 +491,7 @@ var XzibitSelect = createReactClass({
         {this.getSkylight()}
       </div>
     );
-  },
+  }
 });
 
 module.exports = XzibitSelect;


### PR DESCRIPTION
Initial attempt to allow opentip options to be passed through for tooltip modification.

The intention is to allow things that generate a ReactXzibitSelect component to pass in and define openTipOptions that can be used to modify tooltip behaviors.

-----------
Example:

<ReactXzibitSelect
  prop1={}
  prop2={}
  ...
  openTipOptions={{showOn: 'click', hideTriggers: ['target'], hideOn: 'click', target: true}} />
-------------  
  
This is intended to allow for work/resolution on Jira ticket IDEA-45 and its sub-tickets, as most of them deal with issues stemming from tooltip setup/behavior.